### PR TITLE
Fix MediaQuery hinge usage

### DIFF
--- a/design_patterns/lib/dual_view_notepad/dual_view_notepad.dart
+++ b/design_patterns/lib/dual_view_notepad/dual_view_notepad.dart
@@ -1,4 +1,5 @@
 import 'package:dual_screen_samples/dual_view_notepad/data.dart';
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:google_fonts/google_fonts.dart';

--- a/design_patterns/lib/dual_view_restaurants/dual_view_restaurants.dart
+++ b/design_patterns/lib/dual_view_restaurants/dual_view_restaurants.dart
@@ -1,4 +1,5 @@
 import 'package:dual_screen_samples/dual_view_restaurants/data.dart';
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/design_patterns/lib/dual_view_restaurants/mock_widgets.dart
+++ b/design_patterns/lib/dual_view_restaurants/mock_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:dual_screen_samples/dual_view_restaurants/data.dart';
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 

--- a/design_patterns/lib/extended_canvas/extended_canvas.dart
+++ b/design_patterns/lib/extended_canvas/extended_canvas.dart
@@ -1,6 +1,7 @@
 import 'package:dual_screen_samples/dual_view_restaurants/data.dart';
 import 'package:dual_screen_samples/dual_view_restaurants/dual_view_restaurants.dart';
 import 'package:dual_screen_samples/dual_view_restaurants/mock_widgets.dart';
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:flutter/material.dart';
 
 class ExtendedCanvas extends StatefulWidget {

--- a/design_patterns/lib/list_detail/list_detail.dart
+++ b/design_patterns/lib/list_detail/list_detail.dart
@@ -1,3 +1,4 @@
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:flutter/material.dart';
 
 class ListDetail extends StatefulWidget {

--- a/design_patterns/lib/main.dart
+++ b/design_patterns/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:dual_screen_samples/dual_view_restaurants/dual_view_restaurants.
 import 'package:dual_screen_samples/extended_canvas/extended_canvas.dart';
 import 'package:dual_screen_samples/hinge_angle/hinge_angle.dart';
 import 'package:dual_screen_samples/list_detail/list_detail.dart';
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:dual_screen_samples/two_page/two_page.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/design_patterns/lib/mediaquery_hinge.dart
+++ b/design_patterns/lib/mediaquery_hinge.dart
@@ -1,0 +1,14 @@
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
+
+/// Extension method that helps with working with the hinge specifically.
+extension MediaQueryHinge on MediaQueryData {
+  DisplayFeature? get hinge {
+    for (final DisplayFeature e in displayFeatures) {
+      if (e.type == DisplayFeatureType.hinge)
+        return e;
+    }
+    return null;
+  }
+}

--- a/design_patterns/lib/two_page/two_page.dart
+++ b/design_patterns/lib/two_page/two_page.dart
@@ -1,3 +1,4 @@
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:dual_screen_samples/two_page/data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/design_patterns/pubspec.lock
+++ b/design_patterns/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -74,9 +74,9 @@ packages:
   dual_screen:
     dependency: "direct main"
     description:
-      path: "../dual_screen"
-      relative: true
-    source: path
+      name: dual_screen
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "1.0.0+3"
   fake_async:
     dependency: transitive
@@ -311,11 +311,9 @@ packages:
     source: hosted
     version: "2.1.5"
   sky_engine:
-    dependency: "direct overridden"
-    description:
-      path: "/Users/andreidiaconu/work/flutter/engine/src/out/host_debug_unopt/gen/dart-pkg/sky_engine"
-      relative: false
-    source: path
+    dependency: transitive
+    description: flutter
+    source: sdk
     version: "0.0.99"
   source_span:
     dependency: transitive
@@ -358,7 +356,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   transparent_image:
     dependency: transitive
     description:
@@ -442,7 +440,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
@@ -465,5 +463,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/design_patterns/test/display_feature_mocks.dart
+++ b/design_patterns/test/display_feature_mocks.dart
@@ -1,4 +1,5 @@
 import 'package:dual_screen/dual_screen.dart';
+import 'package:dual_screen_samples/mediaquery_hinge.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
`MediaQuery.hinge` was removed from the API during PR review. This adds it back for this repo as an extension method so that the repo builds and is usable.