### PR TITLE
Updated Kotlin gradle plugin version to 1.6.21

### DIFF
--- a/design_patterns/android/build.gradle
+++ b/design_patterns/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
This was the error before this fix:
```
Flutter Fix
[!] Your project requires a newer version of the Kotlin Gradle plugin.
```

`java -version` output:
```
openjdk version "1.8.0_352"
OpenJDK Runtime Environment (build 1.8.0_352-b08)
OpenJDK 64-Bit Server VM (build 25.352-b08, mixed mode)
```

`flutter --version` output:
```
Flutter 3.3.7 • channel stable • https://github.com/flutter/flutter.git
Framework • revision e99c9c7cd9 (3 days ago) • 2022-11-01 16:59:00 -0700
Engine • revision 857bd6b74c
Tools • Dart 2.18.4 • DevTools 2.15.0
```